### PR TITLE
CID-2057: Remove codeOwnersPath from graphql query

### DIFF
--- a/src/main/resources/queries/AllGroupsQuery.graphql
+++ b/src/main/resources/queries/AllGroupsQuery.graphql
@@ -22,7 +22,6 @@ query AllGroupsQuery($group: ID!, $pageCount: Int!, $cursor: String) {
                     share
                 }
                 repository {
-                    codeOwnersPath
                     diskPath
                     rootRef
                 }

--- a/src/main/resources/queries/ProjectByPathQuery.graphql
+++ b/src/main/resources/queries/ProjectByPathQuery.graphql
@@ -20,7 +20,6 @@ fragment ProjectDetails on Project {
         share
     }
     repository {
-        codeOwnersPath
         diskPath
         rootRef
     }

--- a/src/test/resources/mappings/get-groups.json
+++ b/src/test/resources/mappings/get-groups.json
@@ -50,7 +50,6 @@
                   }
                 ],
                 "repository": {
-                  "codeOwnersPath": null,
                   "diskPath": null,
                   "rootRef": "main"
                 },
@@ -86,7 +85,6 @@
                 "lastActivityAt": "2023-03-22T00:11:40Z",
                 "languages": [],
                 "repository": {
-                  "codeOwnersPath": null,
                   "diskPath": null,
                   "rootRef": "main"
                 },
@@ -131,7 +129,6 @@
                   }
                 ],
                 "repository": {
-                  "codeOwnersPath": "/gitlab-org/terraform-provider-gitlab/-/blob/main/.gitlab/CODEOWNERS",
                   "diskPath": null,
                   "rootRef": "main"
                 },
@@ -172,7 +169,6 @@
                   }
                 ],
                 "repository": {
-                  "codeOwnersPath": null,
                   "diskPath": null,
                   "rootRef": "main"
                 },
@@ -197,7 +193,6 @@
                   }
                 ],
                 "repository": {
-                  "codeOwnersPath": null,
                   "diskPath": null,
                   "rootRef": "main"
                 },


### PR DESCRIPTION
— Removed **codeOwnersPath** from the GraphQL query to ensure support for GitLab Community Edition.